### PR TITLE
Hide cursor on window leave

### DIFF
--- a/src/js/cursor.js
+++ b/src/js/cursor.js
@@ -50,6 +50,14 @@ export default class Cursor extends EventEmitter {
             window.removeEventListener('mousemove', this.onMouseMoveEv);
         };
         window.addEventListener('mousemove', this.onMouseMoveEv);
+
+        this.isVisible = true;
+
+        this.hide = this.hide.bind(this);
+        this.show = this.show.bind(this);
+
+        document.body.addEventListener('mouseleave', this.hide);
+        document.body.addEventListener('mouseenter', this.show);
     }
     render() {
         this.renderedStyles['tx'].current = mouse.x - this.bounds.width/2;
@@ -62,7 +70,7 @@ export default class Cursor extends EventEmitter {
         this.DOM.el.style.transform = `translateX(${(this.renderedStyles['tx'].previous)}px) translateY(${this.renderedStyles['ty'].previous}px)`;
         this.DOM.circleInner.setAttribute('r', this.renderedStyles['radius'].previous);
 
-        requestAnimationFrame(() => this.render());
+        if (this.isVisible) requestAnimationFrame(() => this.render());
     }
     createTimeline() {
         // init timeline
@@ -91,6 +99,17 @@ export default class Cursor extends EventEmitter {
     leave() {
         this.renderedStyles['radius'].current = 60;
         this.tl.progress(1).kill();
+    }
+    show() {
+        this.isVisible = true;
+        requestAnimationFrame(() => this.render());
+        gsap.to(this.DOM.el, {duration: 0.9, ease: 'Power3.easeOut', opacity: 1});
+    }
+    hide(ev) {
+        if (!ev.relatedTarget && !ev.toElement) {
+            this.isVisible = false;
+            gsap.to(this.DOM.el, {duration: 0.9, ease: 'Power3.easeOut', opacity: 0});
+        }
     }
     listen() {
         this.on('enter', () => this.enter());

--- a/src/js/cursor2.js
+++ b/src/js/cursor2.js
@@ -51,6 +51,14 @@ export default class Cursor extends EventEmitter {
             window.removeEventListener('mousemove', this.onMouseMoveEv);
         };
         window.addEventListener('mousemove', this.onMouseMoveEv);
+
+        this.isVisible = true;
+
+        this.hide = this.hide.bind(this);
+        this.show = this.show.bind(this);
+
+        document.body.addEventListener('mouseleave', this.hide);
+        document.body.addEventListener('mouseenter', this.show);
     }
     render() {
         this.renderedStyles['tx'].current = mouse.x - this.bounds.width/2;
@@ -64,7 +72,7 @@ export default class Cursor extends EventEmitter {
         this.DOM.circleInner.setAttribute('r', this.renderedStyles['radius'].previous);
         this.DOM.circleInner.style.strokeWidth = `${this.renderedStyles['stroke'].previous}px`;
 
-        requestAnimationFrame(() => this.render());
+        if (this.isVisible) requestAnimationFrame(() => this.render());
     }
     createTimeline() {
         // init timeline
@@ -96,6 +104,17 @@ export default class Cursor extends EventEmitter {
         this.renderedStyles['radius'].current = 60;
         this.renderedStyles['stroke'].current = 1;
         this.tl.progress(1).kill();
+    }
+    show() {
+        this.isVisible = true;
+        requestAnimationFrame(() => this.render());
+        gsap.to(this.DOM.el, {duration: 0.9, ease: 'Power3.easeOut', opacity: 1});
+    }
+    hide(ev) {
+        if (!ev.relatedTarget && !ev.toElement) {
+            this.isVisible = false;
+            gsap.to(this.DOM.el, {duration: 0.9, ease: 'Power3.easeOut', opacity: 0});
+        }
     }
     listen() {
         this.on('enter', () => this.enter());

--- a/src/js/cursor3.js
+++ b/src/js/cursor3.js
@@ -50,6 +50,14 @@ export default class Cursor extends EventEmitter {
             window.removeEventListener('mousemove', this.onMouseMoveEv);
         };
         window.addEventListener('mousemove', this.onMouseMoveEv);
+
+        this.isVisible = true;
+
+        this.hide = this.hide.bind(this);
+        this.show = this.show.bind(this);
+
+        document.body.addEventListener('mouseleave', this.hide);
+        document.body.addEventListener('mouseenter', this.show);
     }
     render() {
         this.renderedStyles['tx'].current = mouse.x - this.bounds.width/2;
@@ -62,7 +70,7 @@ export default class Cursor extends EventEmitter {
         this.DOM.el.style.transform = `translateX(${(this.renderedStyles['tx'].previous)}px) translateY(${this.renderedStyles['ty'].previous}px)`;
         this.DOM.circleInner.setAttribute('r', this.renderedStyles['radius'].previous);
 
-        requestAnimationFrame(() => this.render());
+        if (this.isVisible) requestAnimationFrame(() => this.render());
     }
     createTimeline() {
         // init timeline
@@ -97,6 +105,17 @@ export default class Cursor extends EventEmitter {
     leave() {
         this.renderedStyles['radius'].current = 50;
         this.tl.progress(1).kill();
+    }
+    show() {
+        this.isVisible = true;
+        requestAnimationFrame(() => this.render());
+        gsap.to(this.DOM.el, {duration: 0.9, ease: 'Power3.easeOut', opacity: 1});
+    }
+    hide(ev) {
+        if (!ev.relatedTarget && !ev.toElement) {
+            this.isVisible = false;
+            gsap.to(this.DOM.el, {duration: 0.9, ease: 'Power3.easeOut', opacity: 0});
+        }
     }
     listen() {
         this.on('enter', () => this.enter());

--- a/src/js/cursor4.js
+++ b/src/js/cursor4.js
@@ -50,6 +50,14 @@ export default class Cursor extends EventEmitter {
             window.removeEventListener('mousemove', this.onMouseMoveEv);
         };
         window.addEventListener('mousemove', this.onMouseMoveEv);
+
+        this.isVisible = true;
+
+        this.hide = this.hide.bind(this);
+        this.show = this.show.bind(this);
+
+        document.body.addEventListener('mouseleave', this.hide);
+        document.body.addEventListener('mouseenter', this.show);
     }
     render() {
         this.renderedStyles['tx'].current = mouse.x - this.bounds.width/2;
@@ -62,7 +70,7 @@ export default class Cursor extends EventEmitter {
         this.DOM.el.style.transform = `translateX(${(this.renderedStyles['tx'].previous)}px) translateY(${this.renderedStyles['ty'].previous}px)`;
         this.DOM.circleInner.setAttribute('r', this.renderedStyles['radius'].previous);
 
-        requestAnimationFrame(() => this.render());
+        if (this.isVisible) requestAnimationFrame(() => this.render());
     }
     createTimeline() {
         // init timeline
@@ -92,6 +100,17 @@ export default class Cursor extends EventEmitter {
     leave() {
         this.renderedStyles['radius'].current = 60;
         this.tl.progress(1).kill();
+    }
+    show() {
+        this.isVisible = true;
+        requestAnimationFrame(() => this.render());
+        gsap.to(this.DOM.el, {duration: 0.9, ease: 'Power3.easeOut', opacity: 1});
+    }
+    hide(ev) {
+        if (!ev.relatedTarget && !ev.toElement) {
+            this.isVisible = false;
+            gsap.to(this.DOM.el, {duration: 0.9, ease: 'Power3.easeOut', opacity: 0});
+        }
     }
     listen() {
         this.on('enter', () => this.enter());


### PR DESCRIPTION
The cursor doesn't disappear when the user exits the window, and just sits there. Adding new methods attached to `mouseenter` and `mouseleave` events and restricting `requestAnimationFrame` to run only when `this.isVisible` is true.